### PR TITLE
Allow compound keys in view

### DIFF
--- a/lib/libcouchbase/query_view.rb
+++ b/lib/libcouchbase/query_view.rb
@@ -47,7 +47,7 @@ module Libcouchbase
 
             pairs = []
             options.each { |key, val|
-                if key.to_s.include? 'key' && val[0] != "["
+                if key.to_s.include?('key') && val[0] != "["
                     pairs << "#{key}=#{[val].to_json[1...-1]}"
                 else
                     pairs << "#{key}=#{val}"

--- a/lib/libcouchbase/query_view.rb
+++ b/lib/libcouchbase/query_view.rb
@@ -47,7 +47,7 @@ module Libcouchbase
 
             pairs = []
             options.each { |key, val|
-                if key.to_s.include? 'key'
+                if key.to_s.include? 'key' && val[0] != "["
                     pairs << "#{key}=#{[val].to_json[1...-1]}"
                 else
                     pairs << "#{key}=#{val}"


### PR DESCRIPTION
Allow compound keys in view definitions, to permit some features listed here : 
https://developer.couchbase.com/documentation/server/3.x/admin/Views/views-translateSQL.html

I personnally don't really like n1ql, I'm afraid of possible bad performances, I chose to use extensively map/reduce to query my data. If you want to query ranges or manage order, compound keys are mandatory.